### PR TITLE
dekunobouにおいてfor_rustブランチの代わりにmainブランチを参照するようにした

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,11 +2,11 @@
 fn main(){
     // CMakeLists.txtが存在するディレクトリを指定します
     // プロジェクトディレクトリからの相対位置となります
-    let dst = cmake::build("dekunobou");
+    let dst = cmake::build("dekunobou/web/api/lib/dekunobou_lib/src/cpp");
     println!("cargo:rustc-link-search=native={}", dst.display());
 
     // staticライブラリとして他に利用するライブラリはなし
-    //println!("cargo:rustc-link-lib=static=");
+    println!("cargo:rustc-link-lib=gomp");
 
     // C++ソースコードの場合は必ずこれを追加すること
     println!("cargo:rustc-link-lib=dylib=stdc++");


### PR DESCRIPTION
# 概要
Web版のでくのぼうにおいてバックエンドをRustに変更したため、その資材を利用できるようにしました。
submoduleの参照先をfor_rustブランチからmainにすることで、AIのアップデートを実施した際にdekunobou側でfor_rustブランチへのアップデート内容反映作業を行う必要がなくなり嬉しいです。

# 確認したこと
`cargo build`によりビルドが通るところまで確認済みです。